### PR TITLE
Added confirm delete modal

### DIFF
--- a/src/components/tags/AllTags.js
+++ b/src/components/tags/AllTags.js
@@ -3,10 +3,7 @@ import React, { useEffect, useState } from "react";
 import { NewTagForm } from "./CreateTagForm";
 import { useHistory } from "react-router-dom";
 
-// If tags have custom property, render edit and delete buttons
-
 export const AllTags = () => {
-
     const [tags, setTags] = useState([])
 
     const getTags = () => {
@@ -15,7 +12,6 @@ export const AllTags = () => {
                     setTags(tags)
                 }))
     }
-
 
     useEffect(() => {
         getTags()
@@ -29,14 +25,13 @@ export const AllTags = () => {
     }
 
 return (
-    <> 
-    <div>AllTags Page</div>
+    <>
         <div className="CreateNewTagFormContainer">
             <NewTagForm getTags={getTags} />
         </div>
         {tags.map((tag) => { 
             return <div key={`tag--${tag.id}`}>{tag.label} 
-            {localStorage.getItem("staff") === true ? <>
+            {localStorage.getItem("staff") === "true" ? <>
             <button onClick={() => history.push(`./tags/${tag.id}`)}>edit</button> 
             <button onClick={() => {DeleteTag(tag.id)}}>delete</button>
             </> : null }

--- a/src/components/tags/AllTags.js
+++ b/src/components/tags/AllTags.js
@@ -5,6 +5,7 @@ import { useHistory } from "react-router-dom";
 
 export const AllTags = () => {
     const [tags, setTags] = useState([])
+    const [showAlert, setShowAlert] = useState(0)
 
     const getTags = () => {
         getAllTags()
@@ -20,12 +21,39 @@ export const AllTags = () => {
 
     const history = useHistory()
 
-    const DeleteTag = (id) => {
-        deleteTag(id).then(getTags)
+    const notifyOnClickDelete = () => {
+        return(
+            <>
+                <div className="modal">
+                    <div className="modal-content">
+                        <div className="alert-text">
+                            {
+                                showAlert != -1 ? <p>Are you sure you wish to delete this post?</p>
+                                :
+                                <p>Post Successfully Deleted.</p>
+                            }
+                        </div>
+                        <div className="alert-buttons">
+                            {
+                                showAlert != -1 ? <><button onClick={()=>{
+                                    deleteTag(showAlert).then(()=>{setShowAlert(-1)
+                                    getTags()})}}>Yes</button>
+                                <button onClick={()=>setShowAlert(0)}>No</button></>
+                                :
+                                <button onClick={()=>setShowAlert(0)}>Close</button>
+                            }
+                        </div>
+                    </div>
+                </div>
+            </>
+        )
     }
 
 return (
     <>
+    {
+        showAlert != 0 ? notifyOnClickDelete() : ""
+    }
         <div className="CreateNewTagFormContainer">
             <NewTagForm getTags={getTags} />
         </div>
@@ -33,7 +61,7 @@ return (
             return <div key={`tag--${tag.id}`}>{tag.label} 
             {localStorage.getItem("staff") === "true" ? <>
             <button onClick={() => history.push(`./tags/${tag.id}`)}>edit</button> 
-            <button onClick={() => {DeleteTag(tag.id)}}>delete</button>
+            <button onClick={() => {setShowAlert(tag.id)}}>delete</button>
             </> : null }
             </div>
         })}


### PR DESCRIPTION
# Description

Tags have NOT been added to posts.

Added confirm delete modal to tags

Fixes # (issue)

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Fetch and run this branch
Sign in as an admin and click on the tag manager link in the navbar
Click on the delete button next to one of the tags in the tag list and confirm that the modal appears
Click the "yes" button and confirm that the resource is deleted
