### PR TITLE
Katie approved ps client

### DIFF
--- a/src/components/posts/AllPosts.js
+++ b/src/components/posts/AllPosts.js
@@ -215,12 +215,15 @@ export const AllPosts = () => {
         {
             posts.length > 0
                 ? posts.map((post) => {
+                    {if(post.approved === true){
+                        
                     return <div key={post.id} className="posts">
                         <Post listView={true} cardView={false} post={post} />
                         <button className="post-delete-button" onClick={()=>{
                             setShowAlert(post.id)
                             }}>Delete</button>
                     </div>
+                    }}
                     // needs author name and category, publication date, content 
                 })
                 : "No posts"

--- a/src/components/posts/CreatePosts.js
+++ b/src/components/posts/CreatePosts.js
@@ -64,29 +64,29 @@ export const CreatePosts = ({ getPosts, editing }) => {
         updateForm(newPost)
     }
 
-    // const approvedORNo = () => {
-        //check if person logged in is staff
-        // if(localStorage.getItem('staff')=== true){
-        //     return approved: true}
-        // else {return approved: false}
+    //check if person logged in is staff
         //yes? approved = true 
         //no? approved = false
-    // }
+        const approvedOrNo = () => {
+            if(localStorage.getItem('staff') === "true"){
+                return true}
+            else {return false}
+        }
 
-    const submitPost = (e) => {
+        const submitPost = (e) => {
         e.preventDefault()
         let tagsToAdd = []
-        //let approverYN = ApprovedOrNo()
         if(form.tags && form.tags.length > 0) {
             tagsToAdd = form.tags.map(tag => tag.id)
         }
+        let approvedYN = approvedOrNo()
         const newPost = {
             category: form.categoryId,
             title: form.title,
             publication_date: (new Date()).toISOString().split('T')[0],
             image_url: form.imageUrl,
             content: form.content,
-            approved: 0,
+            approved: approvedYN,
             tags: tagsToAdd
         }
         if(newPost.title && newPost.image_url && newPost.category && newPost.tags.length > 0) {
@@ -223,8 +223,9 @@ export const CreatePosts = ({ getPosts, editing }) => {
 
             <div className="submitButtonCreateNewPostForm">
                 <button onClick={(e) => {
+
                     submitPost(e)
-                    updateForm({ title: "", imageUrl: "", content: "", categoryId: "0" })
+                    updateForm({ title: "", imageUrl: "", content: "", categoryId: "0"})
                 }} className="submit-button">
                     Submit
                 </button>

--- a/src/components/posts/CreatePosts.js
+++ b/src/components/posts/CreatePosts.js
@@ -64,6 +64,7 @@ export const CreatePosts = ({ getPosts, editing }) => {
         updateForm(newPost)
     }
 
+    //To determine if post is approved upon submission...
     //check if person logged in is staff
         //yes? approved = true 
         //no? approved = false

--- a/src/components/posts/CreatePosts.js
+++ b/src/components/posts/CreatePosts.js
@@ -64,9 +64,19 @@ export const CreatePosts = ({ getPosts, editing }) => {
         updateForm(newPost)
     }
 
+    // const approvedORNo = () => {
+        //check if person logged in is staff
+        // if(localStorage.getItem('staff')=== true){
+        //     return approved: true}
+        // else {return approved: false}
+        //yes? approved = true 
+        //no? approved = false
+    // }
+
     const submitPost = (e) => {
         e.preventDefault()
         let tagsToAdd = []
+        //let approverYN = ApprovedOrNo()
         if(form.tags && form.tags.length > 0) {
             tagsToAdd = form.tags.map(tag => tag.id)
         }
@@ -76,7 +86,7 @@ export const CreatePosts = ({ getPosts, editing }) => {
             publication_date: (new Date()).toISOString().split('T')[0],
             image_url: form.imageUrl,
             content: form.content,
-            approved: 1,
+            approved: 0,
             tags: tagsToAdd
         }
         if(newPost.title && newPost.image_url && newPost.category && newPost.tags.length > 0) {


### PR DESCRIPTION
# Description

When a user creates a new post, it will be automatically approved or unapproved based on the type of user. Admin posts are automatically approved. Regular user posts are not approved. (admins will be able to approve user posts, but can't yet.)

The All Posts page will ONLY display APPROVED posts.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.


- New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

check into client side and npm start
Log in as admin. Create a post. That post should show up on All Posts list.
Log in as a regular user. Create a post. That post should not be viewable on all posts. If you check the network tab post.approved should say false. 

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings